### PR TITLE
Lead by example

### DIFF
--- a/docs/50_lead-by-example.mdx
+++ b/docs/50_lead-by-example.mdx
@@ -1,12 +1,11 @@
 ---
-title: "Lead by Example"
+title: "Lead-by-Example"
 hide_table_of_contents: true
 ---
 
 import Lbe from '@site/src/components/LeadByExample.js';
 
-<details>
-    <summary>Introduction</summary>
+## Introduction
 
 NFDI4Chem has a clear vision of how chemistry research data will be collected, processed, archived, shared and published. The development of standards for metadata, minimum information, analytical data formats as well as publication standards includes sample datasets in a standard-compliant manner.
 
@@ -16,10 +15,11 @@ This collection also documents the process of evolving FAIRness of chemistry res
 
 Take a look at the list for inspiration as to what is already possible today!
 
-Please note that the term "pair" used here might describes the classical approach of a scientific publication with its corresponding dataset, but can also be understood as a scientific publication with numerous associated datasets or as a dataset that is the basis of several scientific publications.
-
 Do you want to have your published dataset highlighted here or do you need assistance in the preparation of your dataset for publication? Pledge your dataset to NFDI4Chem! More information can be found [here](https://www.nfdi4chem.de/index.php/2022/02/02/data-pledge-lets-lead-by-example-2/).
-</details>
+
+Please note that the term "pair" used here might describes the classical approach of a scientific publication with its corresponding dataset, but may be also understood more widely as a scientific publication with numerous associated datasets or as a dataset that is the basis of several scientific publications.
+
+## Publication Dataset Pairs
 
 <Lbe />
 

--- a/src/components/LeadByExample.js
+++ b/src/components/LeadByExample.js
@@ -183,14 +183,17 @@ export default function Lbe( {useCategoriesList} ) {
     return (
       <div className="block_lbe">
         <div className="header_lbe">
-          <div className="header_lbe_title"><h3>{title}</h3></div>
+          <div className="header_lbe_title"><h3>{title}</h3>
+          </div>
+            <p><em>{authors}</em>
+            </p>
+            <p><em>{journal}</em> <strong>{pubyear}</strong>, DOI: <a href={linkpub} target="_blank">{doi}</a>.</p>
+
           <div className="header_lbe_link"><MultiUrl name="Permalink" url={"./?text=".concat(doi)} /></div>
         </div>
 
         <p>{subdiscipline.map((tag,idx) => 
           <SubdButton key={idx} name={tag} />
-        )}{tags.map((tag,idx) => 
-          <TagButton key={idx} name={tag} />
         )}</p>
 
         <details className="details_lbe">
@@ -198,19 +201,12 @@ export default function Lbe( {useCategoriesList} ) {
           <summary>Details</summary>
 
           <div className="collapsible_lbe">
-            <h4>Authors</h4>
-            
-            <p><em>{authors}</em></p>
 
             <h4>Description</h4>
 
             <p>{description}</p>
 
-            <h4>Publication</h4>
-
-            <p><em>{journal}</em> <strong>{pubyear}</strong>, DOI: <a href={linkpub} target="_blank">{doi}</a></p>
-
-            <h4>Links to datasets</h4>
+            <h4>Link(s) to dataset(s)</h4>
 
             <p>
               {linkdata.map((props, idx) => (
@@ -229,9 +225,14 @@ export default function Lbe( {useCategoriesList} ) {
 
   function LbeButtons() {
     return(
-      <><div className="filter_lbe"><h4>Filter subdisciplines</h4><p>{subdiscs.map((props, idx) => <SubdButton key={idx} name={props} />)}</p></div>
-      <div className="filter_lbe"><h4>Filter journals</h4><p>{journals.map((props, idx) => <JournalButton key={idx} name={props} />)}</p></div>
-      <div className="filter_lbe"><h4>Filter keywords</h4><p>{categories.map((props, idx) => <TagButton key={idx} name={props} />)}</p></div></>
+      <>
+        <div className="filter_lbe"><h4><br></br>Filter by subdisciplines</h4>
+          <p>{subdiscs.map((props, idx) => <SubdButton key={idx} name={props} />)}</p>
+        </div>
+        <div className="filter_lbe"><h4>Filter by journals</h4>
+          <p>{journals.map((props, idx) => <JournalButton key={idx} name={props} />)}</p>
+        </div>
+      </>
     )
   }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -599,37 +599,6 @@ table thead tr {
 
 /* Lead by Example */
 
-.lbe {
-  display: flex;
-  flex-direction: row-reverse;
-}
-
-.col-searchfilter {
-  padding-left: 0.5rem;
-  width: 35%;
-}
-
-.body_lbe {
-  padding-right: 0.5rem;
-  width: 65%;
-}
-
-@media screen and (max-width: 1200px) {
-.lbe {
-  display: flex;
-  flex-direction: column;
-}
-
-.col-searchfilter {
-  padding: 0;
-  width: 100%;
-}
-
-.body_lbe {
-  padding: 0;
-  width: 100%;
-}}
-
 .block_filter {
   padding: 10px;
   margin: 15px 0px;
@@ -649,25 +618,6 @@ table thead tr {
   margin-bottom: 0.75rem;
   transition: all var(--n4c-transform-time) ease-in-out;
 }
-
-.block_lbe-search{
-  padding: 0.75rem;
-  border: 1px dashed var(--ifm-color-primary);
-  margin-bottom: 0.75rem;
-}
-
-.filter_lbe p {
-  margin: unset;
-}
-
-.filter_lbe h4 {
-  margin: 0.5rem 0;
-}
-
-/* .block_lbe:hover {
-  transform: scale(101%);
-  transition: all var(--n4c-transform-time) ease-in-out;
-} */
 
 .filter_methods {
   width: calc(8/12*100%);
@@ -692,34 +642,6 @@ table thead tr {
   }
 }
 
-.header_lbe {
-  display: flex;
-  align-items: center;
-}
-
-.header_lbe_title {
-  width: 85%;
-  padding: 0.3rem;
-  display: flex;
-  align-items: center;
-}
-
-.header_lbe_link {
-  width: 15%;
-  display: flex;
-  justify-content: right;
-}
-
-@media screen and (max-width: 966px) { .header_lbe {
-  display: flex;
-  flex-wrap: wrap-reverse;
-}
-
-  .header_lbe_title, .header_lbe_link {
-    width: 100%;
-    justify-content: left;
-  }
-}
 
 .details_lbe {
   display: flex; 
@@ -757,7 +679,7 @@ table thead tr {
   padding: 0.5em;
   border-radius: 5px;
   margin: 0.2em;
-  font-size: 11pt;
+  font-size: 10pt;
   background: none;
 }
 


### PR DESCRIPTION
Reverted partially back to the more list like Lead-by-Example page, with filters on top. Also included the introduction text to the markdown file without any need to expand this text to read it. 

The table now also provides essential information i.e. title, authors, journal, year and DOI of publication without the need to expand the table. By expanding each table, readers might then read the description of the dataset(s) and access the datasets via their DOI (or URL in some cases).

I decided to remove the keywords again, as we didn't agree on using keywords in our meeting last week. 

We will soon also provide an updated lbe.json, after we collected all the data.